### PR TITLE
Option to fetch and split JWST `rateints` files

### DIFF
--- a/mastquery/tests/test_query.py
+++ b/mastquery/tests/test_query.py
@@ -4,10 +4,14 @@ import matplotlib.pyplot as plt
 
 from .. import query, overlaps
 
+QUERY = None
+
 def test_query():
     """
     Test basic query
     """
+    global QUERY
+    
     _res = query.run_query(proposal_id=[11359], filters=['G141'])
     assert(len(_res) == 1)
     
@@ -25,16 +29,19 @@ def test_query():
     
     for file in files:
         os.remove(file)
-        
-    return _res
+    
+    QUERY = _res
 
 def test_products():
     """
     Get products info
     """
-    _res = test_query()
-    _prod = query.get_products_table(_res, extensions=['RAW'], 
-                                     use_astroquery=True)
-    assert(len(_prod) == 4)
+    global QUERY
+    
+    if QUERY is not None:
+        _prod = query.get_products_table(QUERY, extensions=['RAW'], 
+                                         use_astroquery=True)
+        
+        assert(len(_prod) == 4)
     
     


### PR DESCRIPTION
Add an option in `mastquery.utils.download_from_mast` to fetch the ``rateints`` data products and, optionally, split them into individual ``rate``-like files.

Example:

```python
>>> mastquery.utils.download_from_mast(['mast:JWST/product/jw02079004001_03201_00003_nrcalong_cal.fits'], force_rate=True, rate_ints=True)
mastquery.utils.split_rateints: jw02079004001_03201_00003_nrcalong_rateints.fits NINTS=7
mastquery.utils.split_rateints: 0 jw02079004001_03201_00003a_nrcalong_rate.fits
mastquery.utils.split_rateints: 1 jw02079004001_03201_00003b_nrcalong_rate.fits
mastquery.utils.split_rateints: 2 jw02079004001_03201_00003c_nrcalong_rate.fits
mastquery.utils.split_rateints: 3 jw02079004001_03201_00003d_nrcalong_rate.fits
mastquery.utils.split_rateints: 4 jw02079004001_03201_00003e_nrcalong_rate.fits
mastquery.utils.split_rateints: 5 jw02079004001_03201_00003f_nrcalong_rate.fits
mastquery.utils.split_rateints: 6 jw02079004001_03201_00003g_nrcalong_rate.fits

{'jw02079004001_03201_00003a_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003b_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003c_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003d_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003e_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003f_nrcalong_rate.fits': ('EXISTS', None, None),
 'jw02079004001_03201_00003g_nrcalong_rate.fits': ('EXISTS', None, None)}
```