### PR TITLE
Avoid removing local variables from FrameLocalsProxy.

### DIFF
--- a/mastquery/utils.py
+++ b/mastquery/utils.py
@@ -749,7 +749,7 @@ def log_function_arguments(LOGFILE, frame, func='func', verbose=True):
         Print messaage to stdout.
     
     """
-    args = inspect.getargvalues(frame).locals
+    args = inspect.getargvalues(frame).locals.copy()
     args.pop('frame')
     for k in list(args.keys()): 
         if hasattr(args[k], '__builtins__'):


### PR DESCRIPTION
In Python 3.13+, it's [no longer possible](https://github.com/python/cpython/issues/125590) to remove (`del` or `pop`) keys from the `FrameLocalsProxy`, used here to log local variables to a file or output stream. This simply copies the locals proxy before trying to remove any items.